### PR TITLE
Send subscription start date/time as string

### DIFF
--- a/subscriptions/dynamodb.js
+++ b/subscriptions/dynamodb.js
@@ -46,7 +46,7 @@ export class DynamoDBSubscriptionService {
                     S: recipientAddress
                 },
                 "subscription_start_date": {
-                    N: new Date().getTime()
+                    N: `${new Date().getTime()}`
                 }
             },
             ConditionExpression: "attribute_not_exists(recipient_address)"


### PR DESCRIPTION
Encountering this error while trying to load default recipients:

```
SerializationException: NUMBER_VALUE cannot be converted to String
```

It turns out that, even for attributes defined as a number, [all values must be sent over as strings](https://stackoverflow.com/questions/71488712/number-value-cannot-be-converted-to-string-when-updating-item). This fixes that issue.

Vexingly, this never showed up during local testing with LocalStack.