### PR TITLE
Fix error checking for upserts

### DIFF
--- a/subscriptions/dynamodb.js
+++ b/subscriptions/dynamodb.js
@@ -55,7 +55,7 @@ export class DynamoDBSubscriptionService {
         try {
             await this.dynamoDBClient.send(new PutItemCommand(input));
         } catch(error) {
-            if (error["__type"] === "ConditionalCheckFailedException") {
+            if ((error["__type"] || "").endsWith("ConditionalCheckFailedException")) {
                 console.debug(`Recipient '${recipientAddress}' is already subscribed`);
                 return;
             }


### PR DESCRIPTION
When a condition check fails while interacting with LocalStack, you get an error with `__type` field of `'ConditionalCheckFailedException'`.

However, DynamoDB proper, hosted by AWS, returns `'com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException'`. This is causing the seeding of default recipients to fail.