### PR TITLE
Try to reduce response spam and capture what causes it

### DIFF
--- a/test/xmtp/bot_handler.test.js
+++ b/test/xmtp/bot_handler.test.js
@@ -71,7 +71,7 @@ describe("Bot Handler", () => {
             })
         })
 
-        describe("the message is not recogniezd", () => {
+        describe("the message is not recognized", () => {
             beforeEach(() => {
                 xmtpContext.message.content = "this message is not handled";
             })
@@ -83,6 +83,18 @@ describe("Bot Handler", () => {
                 expect(subscribedAddresses).to.contain(recipientAddress);
                 expect(sentMessages).to.have.lengthOf(1);
                 expect(sentMessages[0]).to.contain("Sorry, I don't understand");
+            })
+
+            describe("the message is blank", () => {
+                beforeEach(() => {
+                    xmtpContext.message.content = "  ";
+                })
+
+                it("does not sent a response back to the user", async () => {
+                    await handler(xmtpContext);
+
+                    expect(sentMessages).to.be.empty;
+                })
             })
         })
     })

--- a/xmtp/bot_handler.js
+++ b/xmtp/bot_handler.js
@@ -10,12 +10,21 @@ export function NewBotHandler(subscriptionsService, subscriptionAllowlist) {
         const recipientAddress = context.message.senderAddress;
         const isSubscribed = await subscriptionsService.isSubscribed(recipientAddress);
         if (isSubscribed) {
-            switch (context.message.content.toLowerCase()) {
+            const normalizedMessage = context.message.content.trim().toLowerCase();
+            if (!normalizedMessage) {
+                // XMTP can sometimes trigger an echo because of a message sent out by the bot account,
+                // so don't respond to these blank echoes
+                return;
+            }
+
+            switch (normalizedMessage) {
             case "stop":
                 await subscriptionsService.unsubscribe(recipientAddress);
                 await context.reply("You have been unsubscribed from further notifications of free games.");
                 break;
             default:
+                console.debug("Received unhandled message from subscribed user:", normalizedMessage);
+                
                 await context.reply("Sorry, I don't understand. You can message STOP at any time to stop receiving notifications.");
             }
         } else {


### PR DESCRIPTION
Got a report that a user got spammed with the "sorry, I don't understand" message when they received a free game notification. Nothing clear from the logs as to what inspired this, so I'm going to attempt to silence empty messages and to debug log out what might be causing it.