### PR TITLE
Ignore echo

### DIFF
--- a/test/xmtp/bot_handler.test.js
+++ b/test/xmtp/bot_handler.test.js
@@ -49,11 +49,16 @@ describe("Bot Handler", () => {
     })
 
     describe("the sender is subscribed", () => {
+        let botAddress;
         let recipientAddress;
 
         beforeEach(() => {
+            botAddress = "bot.address";
+            xmtpContext.message.recipientAddress = botAddress;
+
             recipientAddress = "sender.is.subscribed";
             xmtpContext.message.senderAddress = recipientAddress;
+            
             subscribedAddresses.push(recipientAddress);
         })
 
@@ -91,6 +96,18 @@ describe("Bot Handler", () => {
                 })
 
                 it("does not sent a response back to the user", async () => {
+                    await handler(xmtpContext);
+
+                    expect(sentMessages).to.be.empty;
+                })
+            })
+
+            describe("the message is from the bot", () => {
+                beforeEach(() => {
+                  xmtpContext.message.senderAddress = botAddress;  
+                })
+
+                it("does not response to the user", async () => {
                     await handler(xmtpContext);
 
                     expect(sentMessages).to.be.empty;

--- a/xmtp/bot_handler.js
+++ b/xmtp/bot_handler.js
@@ -29,8 +29,6 @@ export function NewBotHandler(subscriptionsService, subscriptionAllowlist) {
                 await context.reply("You have been unsubscribed from further notifications of free games.");
                 break;
             default:
-                console.debug("Received unhandled message from subscribed user:", normalizedMessage);
-                
                 await context.reply("Sorry, I don't understand. You can message STOP at any time to stop receiving notifications.");
             }
         } else {

--- a/xmtp/bot_handler.js
+++ b/xmtp/bot_handler.js
@@ -7,6 +7,12 @@ Message STOP at any time to stop receiving notifications.
 
 export function NewBotHandler(subscriptionsService, subscriptionAllowlist) {
     return async (context) => {
+        if (context.message.recipientAddress == context.message.senderAddress) {
+            // XMTP will echo back the message it sent, it seems.
+            // In that case, ignore it.
+            return;
+        }
+        
         const recipientAddress = context.message.senderAddress;
         const isSubscribed = await subscriptionsService.isSubscribed(recipientAddress);
         if (isSubscribed) {


### PR DESCRIPTION
It seems that, if I send a message with the same key being used by a bot, the bot gets the message echoed back to it.