### PR TITLE
Remove default response handler

### DIFF
--- a/test/xmtp/bot_handler.test.js
+++ b/test/xmtp/bot_handler.test.js
@@ -76,32 +76,32 @@ describe("Bot Handler", () => {
             })
         })
 
-        describe("the message is not recognized", () => {
+        describe("the message is 'help'", () => {
             beforeEach(() => {
-                xmtpContext.message.content = "this message is not handled";
+                xmtpContext.message.content = "help";
             })
 
-            it("tells the user that the bot doesn't understand", async () => {
+            it("tells the user where they can submit a bug", async () => {
                 await handler(xmtpContext);
 
                 // the sender should not have been unsubscribed
                 expect(subscribedAddresses).to.contain(recipientAddress);
                 expect(sentMessages).to.have.lengthOf(1);
-                expect(sentMessages[0]).to.contain("Sorry, I don't understand");
-                // The message should include a link telling them where to go log issues.
                 expect(sentMessages[0]).to.contain("https://github.com/jrh3k5/freegames-xmtp/issues");
             })
+        })
 
-            describe("the message is blank", () => {
-                beforeEach(() => {
-                    xmtpContext.message.content = "  ";
-                })
+        describe("the message is not recognized", () => {
+            beforeEach(() => {
+                xmtpContext.message.content = "this message is not handled";
+            })
 
-                it("does not sent a response back to the user", async () => {
-                    await handler(xmtpContext);
+            it("does not respond to the user", async () => {
+                await handler(xmtpContext);
 
-                    expect(sentMessages).to.be.empty;
-                })
+                // the sender should not have been unsubscribed
+                expect(subscribedAddresses).to.contain(recipientAddress);
+                expect(sentMessages).to.be.empty;
             })
 
             describe("the message is from the bot", () => {

--- a/xmtp/bot_handler.js
+++ b/xmtp/bot_handler.js
@@ -5,10 +5,7 @@ This is powered by https://freestuffbot.xyz, so the links you receive will be re
 Message STOP at any time to stop receiving notifications.
 `;
 
-const unhandledInputResponse = `Sorry, I don't understand. You can message STOP at any time to stop receiving notifications.
-\n
-If you are encountering an issue with this bot, please log an issue at https://github.com/jrh3k5/freegames-xmtp/issues
-`;
+const helpResponse = "If you are encountering an issue with this bot, please log an issue at https://github.com/jrh3k5/freegames-xmtp/issues";
 
 export function NewBotHandler(subscriptionsService, subscriptionAllowlist) {
     return async (context) => {
@@ -33,8 +30,11 @@ export function NewBotHandler(subscriptionsService, subscriptionAllowlist) {
                 await subscriptionsService.unsubscribe(recipientAddress);
                 await context.reply("You have been unsubscribed from further notifications of free games.");
                 break;
+            case "help":
+                await context.reply(helpResponse);
+                break;
             default:
-                await context.reply(unhandledInputResponse);
+                // deliberately do nothing, as the bot seems to respond to messages it sends
             }
         } else {
             switch (context.message.content.toLowerCase()) {


### PR DESCRIPTION
The default handler is spamming people relentlessly. My previous efforts to not trigger this behavior have not provided relief, so let's just remove that code path altogether.