### PR TITLE
Decrease polling frequency, pull messages in batch

### DIFF
--- a/queue/game_notification.js
+++ b/queue/game_notification.js
@@ -9,6 +9,8 @@ export function consumeGameNotifications(sqsClient,
                                          gameSQSQueueURL, userSQSQueueURL,
                                          subscriptionsService) {
     const app = Consumer.create({
+        batchSize: 10,
+        pollingWaitTimeMs: 20000,
         messageAttributeNames: [
             "GameID", 
             "GameTitle", 

--- a/queue/user_notification.js
+++ b/queue/user_notification.js
@@ -32,6 +32,8 @@ export function newUserNotificationHandler(notifier, killSwitch) {
 // consumeUserNotifications consumes user notifications enqueued in the given URL.
 export function consumeUserNotifications(sqsClient, sqsQueueURL, messageHandler) {
     const app = Consumer.create({
+        batchSize: 10,
+        pollingWaitTimeMs: 20000,
         messageAttributeNames: [
             "GameID", 
             "GameTitle", 


### PR DESCRIPTION
SQS usage is a bit high for the volume produced this month, so let's reduce the polling frequency and increase the number of messages processed at a time.