### PR TITLE
Add monitoring of ETH sends

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,24 @@ You can specify the following (optional) environmental variables to control acce
 * `XMTP_BOT_DEFAULT_RECIPIENTS`: a comma-delimited list of addresses to be loaded on startup as subscribers who will receive game notifications
 * `XMTP_BOT_SUBSCRIBE_ALLOWLIST`: a comma-delimited list of addresses to which subscribing to the bot is to be limited
 
+##### Gating Behind ETH Sends
+
+(Work in Progress)
+
+By default, users can subscribe by messaging the bot. However, access to subscriptions can be gated behind users who have sent ETH to a configured recipient address. Subscribing users is managed by the `eth_monitor.js` executable.
+
+This requires an Alchemy API key, as this uses the Alchemy transaction subscriptions to listen for ETH sends. This, at this time, requires a high availability of the monitor; if it is down, then it will not automatically detect sends and subscribe users. Manual correction will be necessary at that time.
+
+To configure this behavior, supply the following parameters:
+
+* `ALCHEMY_API_KEY`: your Alchemy API key for the network on which you can receive funds
+* `ALCHEMY_NETWORK_ID`: the network ID (corresponding to the Alchemy SDK's [network ID values](https://github.com/alchemyplatform/alchemy-sdk-js/blob/2593cfff2aa6060c3823166c9af61b346a3ba5c7/src/types/types.ts#L81-L99))
+* `SUBSCRIPTION_RECEIPT_ADDRESS`: the address to which users must send funds in order to subscribe
+* `SUBSCRIPTION_DURATION_MINUTES` (default: 30 days of minutes): the number of minutes a subscription should last
+* `SUBSCRIPTION_MINIMUM_GWEI`: the minimum amount of gwei a user must send to the configured receipt address to subscribe to the bot
+* `SUBSCRIPTION_NETWORK_BLOCKS_PER_MINUTE` (default: 30): the number of blocks the configured network produces in a minute
+
+
 #### Kill Switches
 
 This supports the following kill switches:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ To deploy this project, create a copy of the `.env.sample` file and fill out the
 * `FREESTUFF_WEBHOOK_SECRET`: the secret shared with the freestuffbot.xyz API to authenticate webhook requests
 * `FREESTUFF_API_KEY`: the API key used to make requests to the freestuffbot.xyz API
 * `KEY`: the private key to be used to sign messages sent to XMTP by the bot
+
+#### Bot Access Control
+
+You can specify the following (optional) environmental variables to control access to the bot:
+
 * `XMTP_BOT_DEFAULT_RECIPIENTS`: a comma-delimited list of addresses to be loaded on startup as subscribers who will receive game notifications
 * `XMTP_BOT_SUBSCRIBE_ALLOWLIST`: a comma-delimited list of addresses to which subscribing to the bot is to be limited
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,17 @@ services:
     command: "node bot.js"
   eth_monitor:
     image: node:18
+    depends_on:
+      - localstack
     user: "node"
     working_dir: /home/node/app
     env_file:
       - .env
+    environment:
+      AWS_ACCESS_KEY_ID: anythingwilldoforlocalstack
+      AWS_ENDPOINT: http://localstack:4566
+      AWS_REGION: us-east-1
+      AWS_SECRET_ACCESS_KEY: anythingwilldoforlocalstack
     volumes:
       - ./:/home/node/app
     command: "node eth_monitor.js"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,15 @@ services:
     volumes:
       - ./:/home/node/app
     command: "node bot.js"
+  eth_monitor:
+    image: node:18
+    user: "node"
+    working_dir: /home/node/app
+    env_file:
+      - .env
+    volumes:
+      - ./:/home/node/app
+    command: "node eth_monitor.js"
   localstack:
     container_name: "localstack"
     image: localstack/localstack:3.0.2

--- a/eth_monitor.js
+++ b/eth_monitor.js
@@ -1,0 +1,35 @@
+import dotenv from "dotenv";
+import { Alchemy, Network, AlchemySubscription } from "alchemy-sdk";
+
+dotenv.config();
+
+const receiptAddress = (process.env.SUBSCRIPTION_RECEIPT_ADDRESS || "").toLowerCase();
+if (!receiptAddress) {
+    throw "A receipt address must be specified";
+}
+
+const settings = {
+    apiKey: process.env.ALCHEMY_API_KEY,
+    network: Network[process.env.ALCHEMY_NETWORK_ID]
+};
+
+if (!settings.apiKey) {
+    throw "An Alchemy API key must be provided";
+}
+
+if (!settings.network) {
+    throw "An invalid Alchemy network ID has been specified";
+}
+
+console.log(`Monitoring for ETH sends to address ${receiptAddress} on ${settings.network}`);
+
+new Alchemy(settings).ws.on(
+    {
+        method: AlchemySubscription.MINED_TRANSACTIONS,
+        addresses: [{ to: receiptAddress }]
+    },
+    res => {
+        const sentGwei = parseInt(res.transaction.value, 16);
+        console.log(`${res.transaction.from} sent ${sentGwei}`)
+    }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-sdk/client-sqs": "^3.515.0",
         "@xmtp/content-type-remote-attachment": "^1.1.7",
         "@xmtp/xmtp-js": "^11.3.9",
+        "alchemy-sdk": "^3.1.2",
         "axios": "^1.6.7",
         "chai": "^5.1.0",
         "dotenv": "^16.4.4",
@@ -2543,6 +2544,27 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
     },
+    "node_modules/alchemy-sdk": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/alchemy-sdk/-/alchemy-sdk-3.1.2.tgz",
+      "integrity": "sha512-xpCgQRLektp6imKdGdHyuVHvbMGpaSe22+qvg9jjGx0Wwkh0XgPzSfKwAzFDlkCGMMdazhKCsHu22XP0xh1noQ==",
+      "dependencies": {
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/contracts": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/providers": "^5.7.0",
+        "@ethersproject/units": "^5.7.0",
+        "@ethersproject/wallet": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
+        "axios": "^1.6.5",
+        "sturdy-websocket": "^0.2.1",
+        "websocket": "^1.0.34"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -2715,6 +2737,18 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/bufferutil": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
+      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2907,6 +2941,15 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "node_modules/d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dependencies": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3026,6 +3069,40 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.63",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.63.tgz",
+      "integrity": "sha512-hUCZd2Byj/mNKjfP9jXrdVZ62B8KuA/VoK7X8nUh5qT+AxDmcbvZz041oDVZdbIN1qW6XY9VDNwzkvKnZvK2TQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -3051,6 +3128,25 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esniff/node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -3085,6 +3181,15 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "node_modules/express": {
@@ -3127,6 +3232,19 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
+    },
+    "node_modules/ext/node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/fast-xml-parser": {
       "version": "4.2.5",
@@ -3550,6 +3668,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -3781,6 +3904,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
     "node_modules/node-cache": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
@@ -3790,6 +3918,16 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/normalize-path": {
@@ -4219,6 +4357,11 @@
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
+    "node_modules/sturdy-websocket": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/sturdy-websocket/-/sturdy-websocket-0.2.1.tgz",
+      "integrity": "sha512-NnzSOEKyv4I83qbuKw9ROtJrrT6Z/Xt7I0HiP/e6H6GnpeTDvzwGIGeJ8slai+VwODSHQDooW2CAilJwT9SpRg=="
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -4259,6 +4402,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
+    "node_modules/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -4269,6 +4417,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
       }
     },
     "node_modules/undici": {
@@ -4288,6 +4444,18 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/utils-merge": {
@@ -4316,6 +4484,22 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/websocket": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
+      "dependencies": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/workerpool": {
@@ -4374,6 +4558,14 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
+      "engines": {
+        "node": ">=0.10.32"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@aws-sdk/client-sqs": "^3.515.0",
     "@xmtp/content-type-remote-attachment": "^1.1.7",
     "@xmtp/xmtp-js": "^11.3.9",
+    "alchemy-sdk": "^3.1.2",
     "axios": "^1.6.7",
     "chai": "^5.1.0",
     "dotenv": "^16.4.4",

--- a/subscriptions/eth_send/handler.js
+++ b/subscriptions/eth_send/handler.js
@@ -1,5 +1,6 @@
 export class Handler {
-    constructor(subscriptionDurationBlocks, minimumGwei) {
+    constructor(subscriptionService, subscriptionDurationBlocks, minimumGwei) {
+        this.subscriptionService = subscriptionService;
         this.subscriptionDurationBlocks = subscriptionDurationBlocks;
         this.minimumGwei = minimumGwei;
     }
@@ -10,5 +11,7 @@ export class Handler {
         }
 
         console.log(`${senderAddress} sent ${amount} gwei and would be subscribed for ${this.subscriptionDurationBlocks} blocks`);
+
+        await this.subscriptionService.upsertSubscription(senderAddress);
     }
 }

--- a/subscriptions/eth_send/handler.js
+++ b/subscriptions/eth_send/handler.js
@@ -1,0 +1,14 @@
+export class Handler {
+    constructor(subscriptionDurationBlocks, minimumGwei) {
+        this.subscriptionDurationBlocks = subscriptionDurationBlocks;
+        this.minimumGwei = minimumGwei;
+    }
+
+    async handle(senderAddress, amount) {
+        if (amount < this.minimumGwei) {
+            return
+        }
+
+        console.log(`${senderAddress} sent ${amount} gwei and would be subscribed for ${this.subscriptionDurationBlocks} blocks`);
+    }
+}

--- a/test/subscriptions/eth_send/handler.test.js
+++ b/test/subscriptions/eth_send/handler.test.js
@@ -1,0 +1,39 @@
+import { expect } from "chai";
+import { Handler } from "../../../subscriptions/eth_send/handler.js";
+
+describe("ETH Send Handler", () => {
+    let subscribedUsers;
+    let handler;
+
+    beforeEach(() => {
+        subscribedUsers = [];
+
+        const minimumGwei = 4000;
+        const subscriptionDurationBlocks = 60;
+
+        const subscriptionService = {};
+        subscriptionService.upsertSubscription = async (address) => {
+            subscribedUsers.push(address);
+        };
+
+        handler = new Handler(subscriptionService, subscriptionDurationBlocks, minimumGwei);
+    })
+
+    describe("when the given gwei is less than the minimum amount", () => {
+        it("does nothing", async() => {
+            await handler.handle("0x1234", 3999);
+
+            expect(subscribedUsers).to.be.empty;
+        })
+    })
+
+    describe("when the given gwei is at least the minimum", () => {
+        it("subscribes the user", async() => {
+            const senderAddress = "0xbB5DA99Ae1726681d4369926EC47fAcc15283A28";
+            
+            await handler.handle(senderAddress, 4000);
+
+            expect(subscribedUsers).to.contain(senderAddress);
+        })
+    })
+})


### PR DESCRIPTION
Lay the bones of being able to monitor for ETH sends in order to enable payment-gating of access to the bot.