### PR TITLE
Fix update of pre-existing data

### DIFF
--- a/subscriptions/dynamodb.js
+++ b/subscriptions/dynamodb.js
@@ -140,15 +140,11 @@ export class DynamoDBSubscriptionService {
         updateExpressions.push("active = :active");
 
         const expressionAttributeValues = {};
-        expressionAttributeValues[":active"] = {
-            S: "true"
-        };
+        expressionAttributeValues[":active"] = "true"
 
         if (subscriptionExpiryBlock) {
             updateExpressions.push("subscription_expiry_block = :subscriptionExpiryBlock")
-            expressionAttributeValues[":subscriptionExpiryBlock"] = {
-                S: `${subscriptionExpiryBlock}`
-            }
+            expressionAttributeValues[":subscriptionExpiryBlock"] = `${subscriptionExpiryBlock}`
         }
 
         const blockUpdateCommand = new UpdateCommand({


### PR DESCRIPTION
The way the update is set now, it's setting `active` equal to a map, not a string value of `true`. This explains why the SGI I created wasn't working on bot startup.