### PR TITLE
Increase image cache TTL

### DIFF
--- a/cache/cache.js
+++ b/cache/cache.js
@@ -1,9 +1,9 @@
 import NodeCache from "node-cache";
 
 // builds a new cache
-export function newCache() {
+export function newCache(cacheTTL, maxKeys) {
     return new NodeCache({
-        stdTTL: 30,
-        maxKeys: 5000
+        stdTTL: cacheTTL || 30,
+        maxKeys: maxKeys || 5000
     });
 }

--- a/webhook.js
+++ b/webhook.js
@@ -35,11 +35,11 @@ if (results.state !== 'SUCCESS') {
 }
 const subscriptionsService = new DynamoDBSubscriptionService(dynamodbClient);
 
-const cache = newCache();
+const imageCache = newCache(3600); // cache images for one hour
 
 // Image metadata resolution
 const imageMetadataRetriever = new Retriever();
-const cachingImageMetadataRetriever = new CachingRetriever(imageMetadataRetriever, cache);
+const cachingImageMetadataRetriever = new CachingRetriever(imageMetadataRetriever, imageCache);
 
 // SQS
 const sqsClient = new SQSClient(awsConfig);


### PR DESCRIPTION
The current TTL of 30s means that, since we're only polling and re-polling every 20 seconds, the cache will expire before it gets to be used again. This allows a customization of the cache TTL and increases it to one hour for the image cache.